### PR TITLE
Add optional progress bar instead of % progress.

### DIFF
--- a/src/JeVe_EasyOTA.cpp
+++ b/src/JeVe_EasyOTA.cpp
@@ -92,6 +92,22 @@ int EasyOTA::setupOTA(unsigned long now)
   ArduinoOTA.onEnd([this]() {
     showMessage("OTA done.Reboot...",1);
   });
+  #ifdef OTA_USE_PROGRESS_BAR
+  static char progressBar[OTA_PROGRESS_BAR_SIZE+1];
+  memset(progressBar, ' ', OTA_PROGRESS_BAR_SIZE);
+  progressBar[0] = '[';
+  progressBar[OTA_PROGRESS_BAR_SIZE-1] = ']';
+  progressBar[OTA_PROGRESS_BAR_SIZE] = '\0';
+  ArduinoOTA.onProgress([this](unsigned int progress, unsigned int total) {
+	static unsigned int prevProg = 100;
+    unsigned int prog = progress / (total/(OTA_PROGRESS_BAR_SIZE-2));
+	Serial.println(prog);
+	if ( prog != prevProg) {
+      memset(progressBar+sizeof(char), '=', prog);
+      showMessage(progressBar, 2);
+    }
+  });
+  #else
   ArduinoOTA.onProgress([this](unsigned int progress, unsigned int total) {
     static unsigned int prevPerc = 100;
     unsigned int perc = (progress / (total / 100));
@@ -101,6 +117,7 @@ int EasyOTA::setupOTA(unsigned long now)
       showMessage("OTA upload " + String(roundPerc) + "%", 1);
     }
   });
+  #endif
   ArduinoOTA.onError([this](ota_error_t error) {
     showMessage("OTA Error " + String(error) + ":", 0);
     String line2 = "";

--- a/src/JeVe_EasyOTA.h
+++ b/src/JeVe_EasyOTA.h
@@ -44,6 +44,12 @@
 #define DEFAULT_OTA_PORT 8266
 #define DEFAULT_OTA_HOSTNAME "EasyOta"
 
+#ifdef OTA_USE_PROGRESS_BAR // Enable this via compiler flag
+#ifndef OTA_PROGRESS_BAR_SIZE // Define this via compiler flag to override the default
+#define OTA_PROGRESS_BAR_SIZE 20
+#endif
+#endif
+
 #define EO_GETTER(T, name) T name() { return _##name; }
 #define EO_SETTER(T, name) T name(T name) { T pa##name = _##name; _##name = name; return pa##name; }
 


### PR DESCRIPTION
Just a different option. Note that the showMessage() has line=2. This is because I am using a console-style display instead of a 2-line LCD and the progress bar shouldn't overwrite the "OTA starting..." message.
I would actually prefer if the "OTA starting..." message had line=0.